### PR TITLE
Fixes bottom text getting cut off in Chrome on iPhone and iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@ tinygrad: A simple and powerful neural network framework
 </title>
 <style>
   body {
-    font-family:'Lucida Console', monospace
+    font-family:'Lucida Console', monospace;
+    padding-bottom: 30px;
   }
   .logo {
     font-size: 60px;


### PR DESCRIPTION
## Below shows the current live site using Chrome
![ipad-iphone-using-chrome](https://github.com/geohot/tinyxxx/assets/142481257/856435dd-4507-4790-beb1-ec677e1e7c7c)
